### PR TITLE
fix the @types/jasmine devdependency from ^2.2.30 to 2.5.41

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "zone.js": "^0.6.23"
   },
   "devDependencies": {
-    "@types/jasmine": "^2.2.30",
+    "@types/jasmine": "2.5.41",
     "@types/node": "^6.0.42",
     "angular-cli": "1.0.0-beta.18",
     "codelyzer": "~0.0.26",


### PR DESCRIPTION
breaks on 2.5.42. current version on npm is 2.5.43. who knows why!